### PR TITLE
manifest: Update to BaseApp 24.04 and Runtime 46beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ To know more refer: https://github.com/sugarlabs/speak
 ```
 git clone https://github.com/flathub/org.sugarlabs.Speak.git
 cd org.sugarlabs.Speak
-flatpak -y --user install org.gnome.{Platform,Sdk}//44
+flatpak -y --user install flathub org.gnome.{Platform,Sdk}//46
+flatpak -y --user install org.sugarlabs.BaseApp//24.04
 flatpak-builder --user --force-clean --install build org.sugarlabs.Speak.json
 ```
 

--- a/org.sugarlabs.Speak.json
+++ b/org.sugarlabs.Speak.json
@@ -34,13 +34,29 @@
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
                     "sha256": "7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e",
-                    "only-arches": ["aarch64"]
+                    "only-arches": ["aarch64"],
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://pypi.org/pypi/numpy/json",
+                        "version-query": ".info.version",
+                        "url-query": ".releases | .[$version][] | select(.filename==\"numpy-\" + $version + \"-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\") | .url",
+                        "name": "numpy",
+                        "packagetype": "bdist_wheel"
+                   }
                },
                {
                 "type": "file",
                 "url": "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
                 "sha256": "666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5",
-                "only-arches": ["x86_64"]
+                "only-arches": ["x86_64"],
+                "x-checker-data": {
+                    "type": "json",
+                    "url": "https://pypi.org/pypi/numpy/json",
+                    "version-query": ".info.version",
+                    "url-query": ".releases | .[$version][] | select(.filename==\"numpy-\" + $version + \"-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\") | .url",
+                    "name": "numpy",
+                    "packagetype": "bdist_wheel"
+                }
             }
             ],
             "cleanup": [

--- a/org.sugarlabs.Speak.json
+++ b/org.sugarlabs.Speak.json
@@ -27,18 +27,21 @@
             "name": "numpy",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --no-build-isolation --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} numpy"
+                "pip3 install --exists-action=i --no-build-isolation --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} *.whl"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a0/41/8f53eff8e969dd8576ddfb45e7ed315407d27c7518ae49418be8ed532b07/numpy-1.25.2.tar.gz",
-                    "sha256": "fd608e19c8d7c55021dffd43bfe5492fab8cc105cc8986f813f8c3c048b38760",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "numpy"
-                   }
-               }
+                    "url": "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+                    "sha256": "7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e",
+                    "only-arches": ["aarch64"]
+               },
+               {
+                "type": "file",
+                "url": "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                "sha256": "666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5",
+                "only-arches": ["x86_64"]
+            }
             ],
             "cleanup": [
                 "/bin",

--- a/org.sugarlabs.Speak.json
+++ b/org.sugarlabs.Speak.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.sugarlabs.Speak",
     "base": "org.sugarlabs.BaseApp",
-    "base-version": "23.06",
+    "base-version": "24.04",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "separate-locales": false,
     "command": "sugarapp",

--- a/speak-info.patch
+++ b/speak-info.patch
@@ -2,7 +2,7 @@ diff --git a/activity/activity.info b/activity/activity.info
 index 6867a2f..46cace8 100644
 --- a/activity/activity.info
 +++ b/activity/activity.info
-@@ -2,13 +2,17 @@
+@@ -2,13 +2,18 @@
  name = Speak
  summary = An animated face that speaks whatever you type
  description = Speak is a talking face.  Anything you type will be spoken aloud using a speech synthesizer.  You can adjust the accent, rate and pitch of the voice as well as the shape of the eyes and mouth.  This is a great way to experiment with a speech synthesizer, learn to type or just have fun making a funny face.
@@ -23,4 +23,5 @@ index 6867a2f..46cace8 100644
 -screenshots = https://github.com/sugarlabs/speak/blob/master/screenshots/en/1.png https://github.com/sugarlabs/speak/blob/master/screenshots/en/2.png
 +update_contact = tch@sugarlabs.org
 +developer_name = Sugar Labs Community
++developer_id = org.sugarlabs
 +screenshots = https://raw.githubusercontent.com/sugarlabs/speak/master/screenshots/en/1.png https://raw.githubusercontent.com/sugarlabs/speak/master/screenshots/en/2.png


### PR DESCRIPTION
updated manifest and README file

numpy was throwing an error
`ModuleNotFoundError: No module named 'mesonpy'`
To fix this new module `meson-python` is added to manifest and it is compatible with flatpak-external-data-checker

After this mesonpy reporting module not found
`ModuleNotFoundError: No module named 'pyproject_metadata'`
To fix this new module `pyproject-metadata` is added to manifest and it is  compatible with flatpak-external-data-checker